### PR TITLE
Fix schema for input logs in output log tool

### DIFF
--- a/src/calva_backseat_driver/mcp/requests.cljs
+++ b/src/calva_backseat_driver/mcp/requests.cljs
@@ -104,7 +104,8 @@
      :inputSchema {:type "object"
                    :properties {"query" {:type "string"
                                          :description (param-description tool-name "query")}
-                                "inputs" {:type "string"
+                                "inputs" {:type "array"
+                                          :items {}
                                           :description (param-description tool-name "inputs")}
                                 "maxImages" {:type "number"
                                              :description (param-description tool-name "maxImages")}}
@@ -548,5 +549,4 @@
 
     :else ;; returning nil so that the response is not sent (JSON-RPC notifications)
     nil))
-
 


### PR DESCRIPTION
This pull request makes a small but important change to the `src/calva_backseat_driver/mcp/requests.cljs` file, updating the schema definition for the `inputs` parameter to better reflect its expected data type.

Schema improvement:

* Changed the `inputs` parameter in the `:inputSchema` from a `"string"` type to an `"array"` type, making the schema more accurate and allowing for multiple input values.